### PR TITLE
fix issue #4

### DIFF
--- a/odk2gn/gn2_utils.py
+++ b/odk2gn/gn2_utils.py
@@ -94,7 +94,11 @@ def get_taxon_list(id_liste: int):
     :type id_liste: int
     """
     data = (
-        DB.session.query(Taxref.cd_nom, Taxref.nom_complet, Taxref.nom_vern)
+        DB.session.query(
+            Taxref.cd_nom, 
+            Taxref.lb_nom, 
+            func.split_part(Taxref.nom_vern,',',1)
+        )
         .filter(BibNoms.cd_nom == Taxref.cd_nom)
         .filter(BibNoms.id_nom == CorNomListe.id_nom)
         .filter(CorNomListe.id_liste == id_liste)


### PR DESCRIPTION
Proposition de correctif pour l'issue #4.

On réduit les noms scientifiques au `lb_nom` (répond aussi à un besoin d'ergonomie de la liste sur mobile) et on ne prend que le premier nom vernaculaire avec un `split_part` sur le champ `nom_vern`.

 
![Screenshot_20230301_162531](https://user-images.githubusercontent.com/22891423/222186438-ed535ef6-bbc5-4d17-aca7-c2e0b3865539.png)

![Screenshot_20230301_163124](https://user-images.githubusercontent.com/22891423/222186430-993eb655-edbb-448f-be69-00c7168465fa.png)


