### PR TITLE
Add permissions to Admin module for ODK objects (for GN>=2.13)

### DIFF
--- a/odk2gn/migrations/7a49e76756df_create_odk2gn_object.py
+++ b/odk2gn/migrations/7a49e76756df_create_odk2gn_object.py
@@ -24,91 +24,7 @@ def upgrade():
         INSERT INTO gn_permissions.cor_object_module (id_object, id_module)
         VALUES((SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'), 
                 (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'));
-        INSERT INTO gn_permissions.t_permissions_available (id_module,id_object,id_action,label,scope_filter,sensitivity_filter)
-        VALUES(
-            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
-            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
-            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'C'),
-            'Créer des formulaires ODK',
-            'false',
-            'false'
-            );
-        INSERT INTO gn_permissions.t_permissions_available (id_module,id_object,id_action,label,scope_filter,sensitivity_filter)
-        VALUES(
-            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
-            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
-            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'R'),
-            'Voir des formulaires ODK',
-            'false',
-            'false'
-            );
-        INSERT INTO gn_permissions.t_permissions_available (id_module,id_object,id_action,label,scope_filter,sensitivity_filter)
-        VALUES(
-            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
-            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
-            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'U'),
-            'Modifier des formulaires ODK',
-            'false',
-            'false'
-            );
-        INSERT INTO gn_permissions.t_permissions_available (id_module,id_object,id_action,label,scope_filter,sensitivity_filter)
-        VALUES(
-            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
-            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
-            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'E'),
-            'Exporter des formulaires ODK',
-            'false',
-            'false'
-            );
-        INSERT INTO gn_permissions.t_permissions_available (id_module,id_object,id_action,label,scope_filter,sensitivity_filter)
-        VALUES(
-            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
-            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
-            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'D'),
-            'Supprimer des formulaires ODK',
-            'false',
-            'false'
-            );
-        INSERT INTO gn_permissions.t_permissions (id_role,id_action,id_module,id_object,sensitivity_filter)
-        VALUES(
-            (SELECT id_role FROM utilisateurs.t_roles WHERE nom_role = 'Grp_admin'), 
-            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'C'),
-            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
-            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
-            'false'
-            );
-        INSERT INTO gn_permissions.t_permissions (id_role,id_action,id_module,id_object,sensitivity_filter)
-        VALUES(
-            (SELECT id_role FROM utilisateurs.t_roles WHERE nom_role = 'Grp_admin'), 
-            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'R'),
-            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
-            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
-            'false'
-            );
-         INSERT INTO gn_permissions.t_permissions (id_role,id_action,id_module,id_object,sensitivity_filter)
-        VALUES(
-            (SELECT id_role FROM utilisateurs.t_roles WHERE nom_role = 'Grp_admin'), 
-            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'U'),
-            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
-            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
-            'false'
-            );
-        INSERT INTO gn_permissions.t_permissions (id_role,id_action,id_module,id_object,sensitivity_filter)
-        VALUES(
-            (SELECT id_role FROM utilisateurs.t_roles WHERE nom_role = 'Grp_admin'), 
-            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'E'),
-            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
-            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
-            'false'
-            );
-        INSERT INTO gn_permissions.t_permissions (id_role,id_action,id_module,id_object,sensitivity_filter)
-        VALUES(
-            (SELECT id_role FROM utilisateurs.t_roles WHERE nom_role = 'Grp_admin'), 
-            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'D'),
-            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
-            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
-            'false'
-            );
+
         """
     )
 
@@ -116,10 +32,6 @@ def upgrade():
 def downgrade():
     op.execute(
         """
-        DELETE FROM gn_permissions.t_permissions
-        WHERE id_object in (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN');
-        DELETE FROM gn_permissions.t_permissions_available
-        WHERE id_object in (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN');
         DELETE FROM gn_permissions.cor_object_module 
         WHERE id_object in (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN');
         DELETE FROM gn_permissions.t_objects

--- a/odk2gn/migrations/7a49e76756df_create_odk2gn_object.py
+++ b/odk2gn/migrations/7a49e76756df_create_odk2gn_object.py
@@ -24,6 +24,91 @@ def upgrade():
         INSERT INTO gn_permissions.cor_object_module (id_object, id_module)
         VALUES((SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'), 
                 (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'));
+        INSERT INTO gn_permissions.t_permissions_available (id_module,id_object,id_action,label,scope_filter,sensitivity_filter)
+        VALUES(
+            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
+            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
+            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'C'),
+            'Créer des formulaires ODK',
+            'false',
+            'false'
+            );
+        INSERT INTO gn_permissions.t_permissions_available (id_module,id_object,id_action,label,scope_filter,sensitivity_filter)
+        VALUES(
+            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
+            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
+            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'R'),
+            'Voir des formulaires ODK',
+            'false',
+            'false'
+            );
+        INSERT INTO gn_permissions.t_permissions_available (id_module,id_object,id_action,label,scope_filter,sensitivity_filter)
+        VALUES(
+            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
+            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
+            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'U'),
+            'Modifier des formulaires ODK',
+            'false',
+            'false'
+            );
+        INSERT INTO gn_permissions.t_permissions_available (id_module,id_object,id_action,label,scope_filter,sensitivity_filter)
+        VALUES(
+            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
+            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
+            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'E'),
+            'Exporter des formulaires ODK',
+            'false',
+            'false'
+            );
+        INSERT INTO gn_permissions.t_permissions_available (id_module,id_object,id_action,label,scope_filter,sensitivity_filter)
+        VALUES(
+            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
+            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
+            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'D'),
+            'Supprimer des formulaires ODK',
+            'false',
+            'false'
+            );
+        INSERT INTO gn_permissions.t_permissions (id_role,id_action,id_module,id_object,sensitivity_filter)
+        VALUES(
+            (SELECT id_role FROM utilisateurs.t_roles WHERE nom_role = 'Grp_admin'), 
+            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'C'),
+            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
+            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
+            'false'
+            );
+        INSERT INTO gn_permissions.t_permissions (id_role,id_action,id_module,id_object,sensitivity_filter)
+        VALUES(
+            (SELECT id_role FROM utilisateurs.t_roles WHERE nom_role = 'Grp_admin'), 
+            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'R'),
+            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
+            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
+            'false'
+            );
+         INSERT INTO gn_permissions.t_permissions (id_role,id_action,id_module,id_object,sensitivity_filter)
+        VALUES(
+            (SELECT id_role FROM utilisateurs.t_roles WHERE nom_role = 'Grp_admin'), 
+            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'U'),
+            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
+            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
+            'false'
+            );
+        INSERT INTO gn_permissions.t_permissions (id_role,id_action,id_module,id_object,sensitivity_filter)
+        VALUES(
+            (SELECT id_role FROM utilisateurs.t_roles WHERE nom_role = 'Grp_admin'), 
+            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'E'),
+            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
+            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
+            'false'
+            );
+        INSERT INTO gn_permissions.t_permissions (id_role,id_action,id_module,id_object,sensitivity_filter)
+        VALUES(
+            (SELECT id_role FROM utilisateurs.t_roles WHERE nom_role = 'Grp_admin'), 
+            (SELECT id_action FROM gn_permissions.bib_actions WHERE code_action = 'D'),
+            (SELECT id_module FROM gn_commons.t_modules WHERE module_code = 'ADMIN'), 
+            (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN'),
+            'false'
+            );
         """
     )
 
@@ -31,6 +116,10 @@ def upgrade():
 def downgrade():
     op.execute(
         """
+        DELETE FROM gn_permissions.t_permissions
+        WHERE id_object in (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN');
+        DELETE FROM gn_permissions.t_permissions_available
+        WHERE id_object in (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN');
         DELETE FROM gn_permissions.cor_object_module 
         WHERE id_object in (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN');
         DELETE FROM gn_permissions.t_objects

--- a/odk2gn/migrations/d85b87a1ca62_declare_permissions_available.py
+++ b/odk2gn/migrations/d85b87a1ca62_declare_permissions_available.py
@@ -1,0 +1,97 @@
+"""declare permissions available
+
+Revision ID: d85b87a1ca62
+Revises: 7a49e76756df
+Create Date: 2024-03-13 16:26:32.471062
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d85b87a1ca62"
+down_revision = "7a49e76756df"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO
+            gn_permissions.t_permissions_available (
+                id_module,
+                id_object,
+                id_action,
+                label,
+                scope_filter,
+                sensitivity_filter
+            )
+        SELECT
+            m.id_module,
+            o.id_object,
+            a.id_action,
+            v.label,
+            v.scope_filter,
+            v.sensitivity_filter
+        FROM
+            (
+                VALUES
+                     ('ADMIN', 'ODK2GN', 'C', False, False, 'Créer des formulaires ODK')
+                    ,('ADMIN', 'ODK2GN', 'R', False, False, 'Voir des formulaires ODK')
+                    ,('ADMIN', 'ODK2GN', 'U', False, False, 'Modifier des formulaires ODK')
+                    ,('ADMIN', 'ODK2GN', 'E', False, False, 'Exporter des formulaires ODK')
+                    ,('ADMIN', 'ODK2GN', 'D', False, False, 'Supprimer des formulaires ODK')
+            ) AS v (module_code, object_code, action_code, scope_filter, sensitivity_filter, label)
+        JOIN
+            gn_commons.t_modules m ON m.module_code = v.module_code
+        JOIN
+            gn_permissions.t_objects o ON o.code_object = v.object_code
+        JOIN
+            gn_permissions.bib_actions a ON a.code_action = v.action_code;
+    
+        INSERT INTO
+            gn_permissions.t_permissions (
+                id_role,
+                id_action,
+                id_module,
+                id_object,
+                sensitivity_filter
+            )
+        SELECT
+        	r.id_role,
+            a.id_action,
+            m.id_module,
+            o.id_object,
+            v.sensitivity_filter
+        FROM
+            (
+                VALUES
+                     ('Grp_admin', 'C', 'ADMIN', 'ODK2GN','False')
+                    ,('Grp_admin', 'R', 'ADMIN', 'ODK2GN','False')
+                    ,('Grp_admin', 'U', 'ADMIN', 'ODK2GN','False')
+                    ,('Grp_admin', 'E', 'ADMIN', 'ODK2GN','False')
+                    ,('Grp_admin', 'D', 'ADMIN', 'ODK2GN','False')
+            ) AS v (role_nom, action_code, module_code, object_code, sensitivity_filter)
+        JOIN
+            gn_commons.t_modules m ON m.module_code = v.module_code
+        JOIN
+            gn_permissions.t_objects o ON o.code_object = v.object_code
+        JOIN
+            gn_permissions.bib_actions a ON a.code_action = v.action_code
+        JOIN
+            utilisateurs.t_roles r ON r.nom_role = v.role_nom; 
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        DELETE FROM gn_permissions.t_permissions
+        WHERE id_object in (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN');
+        DELETE FROM gn_permissions.t_permissions_available
+        WHERE id_object in (SELECT id_object FROM gn_permissions.t_objects WHERE code_object = 'ODK2GN');
+        """
+    )

--- a/odk2gn/migrations/d85b87a1ca62_declare_permissions_available.py
+++ b/odk2gn/migrations/d85b87a1ca62_declare_permissions_available.py
@@ -38,11 +38,10 @@ def upgrade():
         FROM
             (
                 VALUES
-                     ('ADMIN', 'ODK2GN', 'C', False, False, 'Créer des formulaires ODK')
-                    ,('ADMIN', 'ODK2GN', 'R', False, False, 'Voir des formulaires ODK')
-                    ,('ADMIN', 'ODK2GN', 'U', False, False, 'Modifier des formulaires ODK')
-                    ,('ADMIN', 'ODK2GN', 'E', False, False, 'Exporter des formulaires ODK')
-                    ,('ADMIN', 'ODK2GN', 'D', False, False, 'Supprimer des formulaires ODK')
+                     ('ADMIN', 'ODK2GN', 'C', False, False, 'Créer des synchronisations ODK')
+                    ,('ADMIN', 'ODK2GN', 'R', False, False, 'Voir les synchronisations ODK')
+                    ,('ADMIN', 'ODK2GN', 'U', False, False, 'Modifier des synchronisations ODK')
+                    ,('ADMIN', 'ODK2GN', 'D', False, False, 'Supprimer des synchronisations ODK')
             ) AS v (module_code, object_code, action_code, scope_filter, sensitivity_filter, label)
         JOIN
             gn_commons.t_modules m ON m.module_code = v.module_code
@@ -71,7 +70,6 @@ def upgrade():
                      ('Grp_admin', 'C', 'ADMIN', 'ODK2GN','False')
                     ,('Grp_admin', 'R', 'ADMIN', 'ODK2GN','False')
                     ,('Grp_admin', 'U', 'ADMIN', 'ODK2GN','False')
-                    ,('Grp_admin', 'E', 'ADMIN', 'ODK2GN','False')
                     ,('Grp_admin', 'D', 'ADMIN', 'ODK2GN','False')
             ) AS v (role_nom, action_code, module_code, object_code, sensitivity_filter)
         JOIN


### PR DESCRIPTION
Ajout des requêtes SQL permettant de créer les permissions pour l'objet ODK2GN sur le module ADMIN (suite aux changements sur le système de permissions introduits dans GN2.13).